### PR TITLE
added callback in options, for custom configuration...

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -9,7 +9,8 @@ markdownItPlugin = (options = {}) ->
   default_opt =
     preset: 'default'
     plugins: []
-    options: {}
+    options: {},
+    configure: ()->{}
   options = _.extend default_opt, options
   md      = markdownIt(options.preset,options.options)
   for plugin in options.plugins
@@ -17,6 +18,9 @@ markdownItPlugin = (options = {}) ->
       md.use require(plugin)
     else if (plugin.constructor == Array && plugin.length == 2)
       md.use require(plugin[0]), plugin[1]
+
+  if(typeof options.configure == "function")
+    options.configure(md, options)
 
   through.obj (file, encoding, callback) ->
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,10 @@ markdownItPlugin = function(options) {
   default_opt = {
     preset: 'default',
     plugins: [],
-    options: {}
+    options: {},
+    configure: function() {
+      return {};
+    }
   };
   options = _.extend(default_opt, options);
   md = markdownIt(options.preset, options.options);
@@ -31,6 +34,9 @@ markdownItPlugin = function(options) {
     } else if (plugin.constructor === Array && plugin.length === 2) {
       md.use(require(plugin[0]), plugin[1]);
     }
+  }
+  if (typeof options.configure === "function") {
+    options.configure(md, options);
   }
   return through.obj(function(file, encoding, callback) {
     var err;


### PR DESCRIPTION
...of the markdown-it instance

This allows a using all init-configurations not exposed through the limited API of the wrapper
(e.g. setting md.renderer rules)
