### PR TITLE
update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
     - '7'
     - '6'
     - '4'
-    - '0.12'
 before_script:
     - npm config set coverage true
 script: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
-    - '0.10'
-    - '0.11'
+    - '7'
+    - '6'
+    - '4'
+    - '0.12'
 before_script:
     - npm config set coverage true
 script: npm test

--- a/index.js
+++ b/index.js
@@ -46,8 +46,8 @@ markdownItPlugin = function(options) {
       file.contents = new Buffer(md.render(file.contents.toString()));
       file.path = gutil.replaceExtension(file.path, '.html');
       this.push(file);
-    } catch (_error) {
-      err = _error;
+    } catch (error) {
+      err = error;
       callback(new gutil.PluginError('gulp-markdown-it', err, {
         fileName: file.path,
         showstack: true

--- a/package.json
+++ b/package.json
@@ -24,23 +24,23 @@
   },
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "through2": "^0.6.1",
+    "through2": "^2.0.3",
     "underscore": "^1.8.2",
-    "markdown-it": "^4.x"
+    "markdown-it": "^8.x"
   },
   "devDependencies": {
     "coffee-script": "^1.7.1",
     "coffeelint": "^1.4.0",
     "coveralls": "^2.8.0",
-    "del": "^1.1.1",
-    "istanbul": "^0.3.8",
-    "mocha": "^2.2.1",
+    "del": "^2.2.2",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.2.0",
     "gulp": "^3.5.2",
     "gulp-coffee": "^2.1.2",
     "gulp-util": "^3.0.4",
-    "should": "^5.2.0",
-    "gulp-bump": "^0.3.0",
-    "gulp-git": "^1.1.0",
+    "should": "^11.2.1",
+    "gulp-bump": "^2.7.0",
+    "gulp-git": "^2.1.0",
     "gulp-tag-version": "^1.2.1",
     "markdown-it-checkbox": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "markdown-it-checkbox": "^1.1.0"
   },
   "engines": {
-    "node": ">=0.10.0",
+    "node": ">=4.2.0",
     "npm": ">=1.3.7"
   },
   "license": "MIT"


### PR DESCRIPTION
I've updated the dependencies and all the tests passed, but doesn't pass travis-ci since the package allows anything as low as node 0.10.0. Would you consider making version bump for this gulp plugin  only supports node 4 LTS or higher?