### PR TITLE
Handle plugin instances

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,10 @@ markdownItPlugin = function(options) {
     if (typeof plugin === "string") {
       md.use(require(plugin));
     } else if (plugin.constructor === Array && plugin.length === 2) {
-      md.use(require(plugin[0]), plugin[1]);
+      let pluginModule = (typeof plugin[0] === 'string')
+        ? require(plugin[0])
+        : plugin[0]; // Use it as is
+      md.use(pluginModule, plugin[1]);
     }
   }
   return through.obj(function(file, encoding, callback) {


### PR DESCRIPTION
Currently the Gulp plugin expects Markdown-it plugins to be passed as module names (eg. `"some-markdown-it-plugin"`).

However, sometimes this does not work. For example, [markdown-it-mathjax](https://github.com/classeur/markdown-it-mathjax) must be instanciated:

    var md = require('markdown-it')()
        .use(require('markdown-it-mathjax')()); // Note the "()"

When this happens, it would be useful to bypass this mechanism and create the plugin ourself:

    ...
    .pipe(markdown_it({
        plugins: [
            [require('markdown-it-mathjax')(), {}]
        ]
    }))
    ....

This is the purpose of this PR. The previous behavior is unchanged: you can still pass a string, which holds for the module name. But you can also whatever you want, which will be used as is.
